### PR TITLE
Update ApiResult.php

### DIFF
--- a/src/LoLApi/Result/ApiResult.php
+++ b/src/LoLApi/Result/ApiResult.php
@@ -15,7 +15,7 @@ class ApiResult
     protected $httpResponse;
 
     /** @var array */
-    protected $result;
+    public $result;
 
     /** @var string */
     protected $url;


### PR DESCRIPTION
the result attribute as protected, prevents it from being extracted in foreach.It was placed as public and the problem was solved.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/babacooll/lol-api/4)

<!-- Reviewable:end -->
