### PR TITLE
Allow this lib to be used with Symfony4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Wrapper for League of Legends API",
     "require": {
         "guzzlehttp/guzzle": "^6.0",
-        "symfony/cache": "^3.2"
+        "symfony/cache": "^3.2|^4.0"
     },
     "keywords": [
         "lol", "api" , "league of legends", "lol api", "library"


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/babacooll/lol-api/15)
<!-- Reviewable:end -->

Without this it's impossible to install in a Symfony4 application since the cache component is locked at version 3.x
