### PR TITLE
API V3 is dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ for ($i = 0; $i < 100; $i++) {
 
 | API        | Version           |
 | ------------- |-------------| 
-| [Summoner API](https://developer.riotgames.com/api-methods/)      | ![v3](https://img.shields.io/badge/v3-latest-green.svg)|  
+| [Summoner API](https://developer.riotgames.com/api-methods/)      | ![v3](https://img.shields.io/badge/v4-latest-green.svg)|  
 | [Match API](https://developer.riotgames.com/api-methods/)      | ![v3](https://img.shields.io/badge/v3-missing_methods-orange.svg)|  
 | [Champion API](https://developer.riotgames.com/api-methods/)      | ![v3](https://img.shields.io/badge/v3-latest-green.svg)|  
 | [Spetactor API](https://developer.riotgames.com/api-methods/)      | ![v3](https://img.shields.io/badge/v3-latest-green.svg)|  
 | [Static Data API](https://developer.riotgames.com/api-methods/)      | ![v3](https://img.shields.io/badge/v3-latest-green.svg)|  
-| [League API](https://developer.riotgames.com/api-methods/)      | ![v3](https://img.shields.io/badge/v3-latest-green.svg)|  
+| [League API](https://developer.riotgames.com/api-methods/)      | ![v3](https://img.shields.io/badge/v4-latest-green.svg)|  
 | [Status API](https://developer.riotgames.com/api-methods/)      | ![v3](https://img.shields.io/badge/v3-latest-green.svg)|  
 | [Champion Mastery API](https://developer.riotgames.com/api-methods/)      | ![v3](https://img.shields.io/badge/v3-latest-green.svg)|  
 | [Masteries API](https://developer.riotgames.com/api-methods/)      | ![v3](https://img.shields.io/badge/v3-latest-green.svg)|  

--- a/src/LoLApi/Api/LeagueApi.php
+++ b/src/LoLApi/Api/LeagueApi.php
@@ -7,15 +7,14 @@ use LoLApi\Result\ApiResult;
 /**
  * Class LeagueApi
  *
- * @package LoLApi\Api
  * @see     https://developer.riotgames.com/api-methods/
  */
 class LeagueApi extends BaseApi
 {
-    const API_URL_LEAGUE_POSITION_BY_SUMMONER_ID = '/lol/league/v4/positions/by-summoner/{encryptedSummonerId}';
-    const API_URL_LEAGUE_CHALLENGER = '/lol/league/v4/challengerleagues/by-queue/{queue}';
-    const API_URL_LEAGUE_MASTER = '/lol/league/v4/masterleagues/by-queue/{queue}';
-    const API_URL_LEAGUE_GRAND_MASTER = '/lol/league/v4/grandmasterleagues/by-queue/{queue}';
+    const API_URL_LEAGUE_POSITION_BY_SUMMONER_ID = '/lol/league/v4/entries/by-summoner/{encryptedSummonerId}';
+    const API_URL_LEAGUE_CHALLENGER              = '/lol/league/v4/challengerleagues/by-queue/{queue}';
+    const API_URL_LEAGUE_MASTER                  = '/lol/league/v4/masterleagues/by-queue/{queue}';
+    const API_URL_LEAGUE_GRAND_MASTER            = '/lol/league/v4/grandmasterleagues/by-queue/{queue}';
 
     /**
      * @param int $summonerId

--- a/src/LoLApi/Api/LeagueApi.php
+++ b/src/LoLApi/Api/LeagueApi.php
@@ -12,22 +12,10 @@ use LoLApi\Result\ApiResult;
  */
 class LeagueApi extends BaseApi
 {
-    const API_URL_LEAGUE_BY_SUMMONER_ID = '/lol/league/v3/leagues/by-summoner/{summonerId}';
     const API_URL_LEAGUE_POSITION_BY_SUMMONER_ID = '/lol/league/v4/positions/by-summoner/{encryptedSummonerId}';
-    const API_URL_LEAGUE_CHALLENGER = '/lol/league/v3/challengerleagues/by-queue/{queue}';
-    const API_URL_LEAGUE_MASTER = '/lol/league/v3/masterleagues/by-queue/{queue}';
-
-    /**
-     * @param int $summonerId
-     *
-     * @return ApiResult
-     */
-    public function getLeagueBySummonerId($summonerId)
-    {
-        $url = str_replace('{summonerId}', $summonerId, self::API_URL_LEAGUE_BY_SUMMONER_ID);
-
-        return $this->callApiUrl($url, []);
-    }
+    const API_URL_LEAGUE_CHALLENGER = '/lol/league/v4/challengerleagues/by-queue/{queue}';
+    const API_URL_LEAGUE_MASTER = '/lol/league/v4/masterleagues/by-queue/{queue}';
+    const API_URL_LEAGUE_GRAND_MASTER = '/lol/league/v4/grandmasterleagues/by-queue/{queue}';
 
     /**
      * @param int $summonerId
@@ -42,7 +30,7 @@ class LeagueApi extends BaseApi
     }
 
     /**
-     * @param string $gameQueueType (Can be RANKED_SOLO_5x5, RANKED_TEAM_3x3, RANKED_TEAM_5x5)
+     * @param string $gameQueueType (Can be RANKED_SOLO_5x5, RANKED_FLEX_SR, RANKED_FLEX_TT)
      *
      * @return ApiResult
      */
@@ -54,11 +42,23 @@ class LeagueApi extends BaseApi
     }
 
     /**
-     * @param string $gameQueueType (Can be RANKED_SOLO_5x5, RANKED_TEAM_3x3, RANKED_TEAM_5x5)
+     * @param string $gameQueueType (Can be RANKED_SOLO_5x5, RANKED_FLEX_SR, RANKED_FLEX_TT)
      *
      * @return ApiResult
      */
     public function getMasterLeagues($gameQueueType)
+    {
+        $url = str_replace('{queue}', $gameQueueType, self::API_URL_LEAGUE_MASTER);
+
+        return $this->callApiUrl($url, []);
+    }
+
+    /**
+     * @param string $gameQueueType (Can be RANKED_SOLO_5x5, RANKED_FLEX_SR, RANKED_FLEX_TT)
+     *
+     * @return ApiResult
+     */
+    public function getGrandMasterLeagues($gameQueueType)
     {
         $url = str_replace('{queue}', $gameQueueType, self::API_URL_LEAGUE_MASTER);
 

--- a/src/LoLApi/Api/LeagueApi.php
+++ b/src/LoLApi/Api/LeagueApi.php
@@ -13,7 +13,7 @@ use LoLApi\Result\ApiResult;
 class LeagueApi extends BaseApi
 {
     const API_URL_LEAGUE_BY_SUMMONER_ID = '/lol/league/v3/leagues/by-summoner/{summonerId}';
-    const API_URL_LEAGUE_POSITION_BY_SUMMONER_ID = '/lol/league/v3/positions/by-summoner/{summonerId}';
+    const API_URL_LEAGUE_POSITION_BY_SUMMONER_ID = '/lol/league/v4/positions/by-summoner/{encryptedSummonerId}';
     const API_URL_LEAGUE_CHALLENGER = '/lol/league/v3/challengerleagues/by-queue/{queue}';
     const API_URL_LEAGUE_MASTER = '/lol/league/v3/masterleagues/by-queue/{queue}';
 
@@ -36,7 +36,7 @@ class LeagueApi extends BaseApi
      */
     public function getLeaguePositionsBySummonerId($summonerId)
     {
-        $url = str_replace('{summonerId}', $summonerId, self::API_URL_LEAGUE_POSITION_BY_SUMMONER_ID);
+        $url = str_replace('{encryptedSummonerId}', $summonerId, self::API_URL_LEAGUE_POSITION_BY_SUMMONER_ID);
 
         return $this->callApiUrl($url, []);
     }

--- a/src/LoLApi/Api/SummonerApi.php
+++ b/src/LoLApi/Api/SummonerApi.php
@@ -12,9 +12,9 @@ use LoLApi\Result\ApiResult;
  */
 class SummonerApi extends BaseApi
 {
-    const API_URL_SUMMONER_BY_NAME = '/lol/summoner/v3/summoners/by-name/{summonerName}';
-    const API_URL_SUMMONER_BY_ID = '/lol/summoner/v3/summoners/{summonerId}';
-    const API_URL_SUMMONER_BY_ACCOUNT_ID = '/lol/summoner/v3/summoners/by-account/{accountId}';
+    const API_URL_SUMMONER_BY_NAME = '/lol/summoner/v4/summoners/by-name/{summonerName}';
+    const API_URL_SUMMONER_BY_ID = '/lol/summoner/v4/summoners/{summonerId}';
+    const API_URL_SUMMONER_BY_ACCOUNT_ID = '/lol/summoner/v4/summoners/by-account/{accountId}';
 
     /**
      * @param string $summonerName

--- a/src/LoLApi/Api/SummonerApi.php
+++ b/src/LoLApi/Api/SummonerApi.php
@@ -13,8 +13,8 @@ use LoLApi\Result\ApiResult;
 class SummonerApi extends BaseApi
 {
     const API_URL_SUMMONER_BY_NAME = '/lol/summoner/v4/summoners/by-name/{summonerName}';
-    const API_URL_SUMMONER_BY_ID = '/lol/summoner/v4/summoners/{summonerId}';
-    const API_URL_SUMMONER_BY_ACCOUNT_ID = '/lol/summoner/v4/summoners/by-account/{accountId}';
+    const API_URL_SUMMONER_BY_ID = '/lol/summoner/v4/summoners/{encryptedSummonerId}';
+    const API_URL_SUMMONER_BY_ACCOUNT_ID = '/lol/summoner/v4/summoners/by-account/{encryptedAccountId}';
 
     /**
      * @param string $summonerName
@@ -33,9 +33,9 @@ class SummonerApi extends BaseApi
      *
      * @return ApiResult
      */
-    public function getSummonerBySummonerId($summonerId)
+    public function getSummonerBySummonerId($encryptedSummonerId)
     {
-        $url = str_replace('{summonerId}', $summonerId, self::API_URL_SUMMONER_BY_ID);
+        $url = str_replace('{encryptedSummonerId}', $encryptedSummonerId, self::API_URL_SUMMONER_BY_ID);
 
         return $this->callApiUrl($url, []);
     }
@@ -45,9 +45,9 @@ class SummonerApi extends BaseApi
      *
      * @return ApiResult
      */
-    public function getSummonerByAccountId($accountId)
+    public function getSummonerByAccountId($encryptedAccountId)
     {
-        $url = str_replace('{accountId}', $accountId, self::API_URL_SUMMONER_BY_ACCOUNT_ID);
+        $url = str_replace('{encryptedAccountId}', $encryptedAccountId, self::API_URL_SUMMONER_BY_ACCOUNT_ID);
 
         return $this->callApiUrl($url, []);
     }

--- a/src/LoLApi/Tests/Api/BaseApiTest.php
+++ b/src/LoLApi/Tests/Api/BaseApiTest.php
@@ -265,13 +265,6 @@ class BaseApiTest extends AbstractApiTest
         return [
             [
                 'getLeagueApi',
-                'getLeagueBySummonerId',
-                [
-                    5
-                ]
-            ],
-            [
-                'getLeagueApi',
                 'getLeaguePositionsBySummonerId',
                 [
                     5


### PR DESCRIPTION
https://www.riotgames.com/en/DevRel/player-universally-unique-identifiers-and-a-new-security-layer

They switched to API v4. 

All the calls to API v3 which has an equivalent to API v4 are no longer working. So without this patch, this library is not functionnal.

PS: I migrated only few endpoint, the one that I use on my app.